### PR TITLE
Feature : Allow translating ActiveStorage attachments

### DIFF
--- a/lib/para/i18n.rb
+++ b/lib/para/i18n.rb
@@ -8,6 +8,11 @@ require 'para/i18n/model'
 require 'para/i18n/resources_table'
 require 'para/i18n/resources_buttons'
 
+require 'para/i18n/attribute_translation'
+require 'para/i18n/attribute_translation/base'
+require 'para/i18n/attribute_translation/simple_attribute'
+require 'para/i18n/attribute_translation/attachment'
+
 require 'para/i18n/friendly_id'
 
 require 'para/i18n/i18n_input'

--- a/lib/para/i18n/attribute_translation.rb
+++ b/lib/para/i18n/attribute_translation.rb
@@ -1,0 +1,26 @@
+module Para
+  module I18n
+    # This module redirects the reading and writing of the translated attributes to the
+    # right attribute translation class
+    #
+    module AttributeTranslation
+      def self.read(locale, resource, attribute)
+        attribute_translation_class(locale, resource.class, attribute).read(resource)
+      end
+
+      def self.write(locale, resource, attribute, value)
+        attribute_translation_class(locale, resource.class, attribute).write(resource, value)
+      end
+
+      def self.attribute_translation_class(locale, model, attribute)
+        attribute_translation_class = if AttributeTranslation::Attachment.matches?(model, attribute)
+          AttributeTranslation::Attachment.new(locale, model, attribute)
+        else
+          AttributeTranslation::SimpleAttribute.new(locale, model, attribute)
+        end
+      end
+    end
+  end
+end
+
+

--- a/lib/para/i18n/attribute_translation/attachment.rb
+++ b/lib/para/i18n/attribute_translation/attachment.rb
@@ -1,0 +1,58 @@
+module Para
+  module I18n
+    module AttributeTranslation
+      class Attachment < Para::I18n::AttributeTranslation::Base
+        def read(resource)
+          attachment = resource.public_send(reflection_name)
+
+          if default_locale? || attachment.attached? || !fallback_locale
+            attachment
+          elsif fallback_locale
+            self.class.new(fallback_locale, model, attribute).read(resource)
+          end
+        end
+
+        def write(resource, value)
+          resource.public_send(:"#{reflection_name}=", value)
+        end
+
+        def self.matches?(model, attribute)
+          model.reflections.key?("#{attribute}_attachment") &&
+            model.reflections.key?("#{attribute}_blob")
+        end
+
+        def self.prepare(model, attribute)
+          return unless matches?(model, attribute)
+
+          (I18n.available_locales - [I18n.default_locale]).each do |locale|
+            new(locale, model, attribute).prepare_translated_attachment
+          end
+        end
+
+        def prepare_translated_attachment
+          model.alias_method(untranslated_getter_name, attribute)
+          model.alias_method(untranslated_setter_name, :"#{attribute}=")
+          model.has_one_attached(reflection_name)
+        end
+
+        private
+
+        def reflection_name
+          @reflection_name ||= if default_locale?
+            untranslated_getter_name
+          else
+            [attribute, locale, "translation"].join("_")
+          end
+        end
+
+        def untranslated_getter_name
+          @untranslated_getter_name ||= :"untranslated_#{attribute}"
+        end
+
+        def untranslated_setter_name
+          @untranslated_setter_name ||= :"untranslated_#{attribute}="
+        end
+      end
+    end
+  end
+end

--- a/lib/para/i18n/attribute_translation/base.rb
+++ b/lib/para/i18n/attribute_translation/base.rb
@@ -1,0 +1,23 @@
+module Para
+  module I18n
+    module AttributeTranslation
+      class Base
+        attr_reader :locale, :model, :attribute
+
+        def initialize(locale, model, attribute)
+          @locale = locale.to_s
+          @model = model
+          @attribute = attribute.to_s
+        end
+
+        def default_locale?
+          @default_locale ||= locale == I18n.default_locale.to_s
+        end
+
+        def fallback_locale
+          @fallback_locale ||= Para::I18n::Fallbacks.i18n_fallback_for(locale.to_sym)
+        end
+      end
+    end
+  end
+end

--- a/lib/para/i18n/attribute_translation/simple_attribute.rb
+++ b/lib/para/i18n/attribute_translation/simple_attribute.rb
@@ -1,0 +1,37 @@
+module Para
+  module I18n
+    module AttributeTranslation
+      class SimpleAttribute < Para::I18n::AttributeTranslation::Base
+        def read(resource)
+          # Directly read the plain column / store accessor if the current locale is the
+          # default one..
+          if default_locale? && attribute != "_disabled_for_locale"
+            return resource.read_plain_or_store_attribute(attribute)
+          end
+
+          translations = resource.model_translations[locale]
+
+          if translations && (translation = translations[attribute])
+            translation
+          elsif fallback_locale
+            # If no translation was returned, try to fallback to the next locale
+            self.class.new(fallback_locale, model, attribute).read(resource)
+          end
+        end
+
+        def write(resource, value)
+          if default_locale? && attribute != "_disabled_for_locale"
+            return resource.write_plain_or_store_attribute(attribute, value)
+          end
+
+          # did not us ||= here to fix first assignation.
+          # Did not investigate on why ||= does not work
+          resource.model_translations[locale] = {} unless resource.model_translations[locale]
+          resource.model_translations[locale][attribute] = value
+          resource._translations_will_change!
+          value
+        end
+      end
+    end
+  end
+end

--- a/lib/para/i18n/model.rb
+++ b/lib/para/i18n/model.rb
@@ -9,27 +9,11 @@ module Para
       end
 
       def read_translated_attribute(field, locale = ::I18n.locale)
-        return read_plain_or_store_attribute(field) if locale == ::I18n.default_locale && field != :_disabled_for_locale
-
-        if model_translations[locale.to_s]
-          if (translation = model_translations[locale.to_s][field.to_s])
-            return translation
-          end
-        end
-
-        # If no translation was returned, try to fallback to the next locale
-        if (fallback_locale = Fallbacks.i18n_fallback_for(locale))
-          read_translated_attribute(field, fallback_locale)
-        end
+        Para::I18n::AttributeTranslation.read(locale, self, field)
       end
 
-      def write_translated_attribute field, value, locale = ::I18n.locale
-        return write_plain_or_store_attribute(field, value) if locale == ::I18n.default_locale && field != :_disabled_for_locale
-
-        # did not us ||= here to fix first assignation.
-        # Did not investigate on why ||= does not work
-        model_translations[locale.to_s] = {} unless model_translations[locale.to_s]
-        model_translations[locale.to_s][field.to_s] = value
+      def write_translated_attribute(field, value, locale = ::I18n.locale)
+        Para::I18n::AttributeTranslation.write(locale, self, field, value)
       end
 
       def model_translations
@@ -43,7 +27,7 @@ module Para
       end
 
       def translation_for(locale)
-        case locale
+        case locale.to_sym
         when I18n.default_locale then default_locale_translations
         else model_translations[locale.to_s] || {}
         end.with_indifferent_access
@@ -53,8 +37,10 @@ module Para
         self.class.translates? && _disabled_for_locale
       end
 
-      private
-
+      # This method allows reading an attribute from the ActiveRecord table, whether it's
+      # a plain column of the table, or a field of a store (hash, json etc.) of the table,
+      # accessed through the ActiveRecord.store_accessor interface.
+      #
       def read_plain_or_store_attribute(field)
         if plain_column?(field)
           read_attribute(field)
@@ -74,6 +60,8 @@ module Para
           raise ActiveRecord::UnknownAttributeError.new(self, field)
         end
       end
+
+      private
 
       def plain_column?(field)
         self.class.columns_hash.key?(field.to_s)
@@ -99,13 +87,7 @@ module Para
           self.translatable = true
 
           fields.each do |field|
-            define_method field do
-              read_translated_attribute(field)
-            end
-
-            define_method :"#{ field }=" do |value|
-              write_translated_attribute(field, value)
-            end
+            prepare_attribute_translation(field)
           end
 
           define_method(:_disabled_for_locale) do
@@ -119,6 +101,21 @@ module Para
 
         def translates?
           translatable
+        end
+
+        private
+
+        def prepare_attribute_translation(attribute)
+          # Delegate ActiveStorage fields handling to the Para::I18n::ActiveStorage module
+          Para::I18n::AttributeTranslation::Attachment.prepare(self, attribute)
+
+          define_method(attribute) do
+            read_translated_attribute(attribute)
+          end
+
+          define_method(:"#{attribute}=") do |value|
+            write_translated_attribute(attribute, value)
+          end
         end
       end
     end

--- a/lib/para/i18n/model.rb
+++ b/lib/para/i18n/model.rb
@@ -106,7 +106,8 @@ module Para
         private
 
         def prepare_attribute_translation(attribute)
-          # Delegate ActiveStorage fields handling to the Para::I18n::ActiveStorage module
+          # Let the Para::I18n::AttributeTranslation::Attachment module handle
+          # ActiveStorage attachment fields translation preparation.
           Para::I18n::AttributeTranslation::Attachment.prepare(self, attribute)
 
           define_method(attribute) do


### PR DESCRIPTION
The `.translates` API is totally unchanged, so you only need to add you file attachment name to your `.translates` calls to make targeted files translatable. Example : 

```ruby
has_one_attached :image

translates :image
```

Then in the `_translation_fields` views : 

```ruby
= form.input :image, as: :i18n, locale: @target_locale, input_html: { as: :image }
```